### PR TITLE
reverse text direction when using upsidedown command

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,9 @@ module.exports = class RoleColorEverywhere extends Plugin {
         if (category === "varied") return this.makeVaried(text);
         const replacementList = replacements[category];
         text = text.split("");
+
+        if (category === "upsidedown") text = text.reverse()
+        
         for (let c = 0; c < text.length; c++) {
             const index = replaceable.indexOf(text[c]);
             if (index < 0) continue; // not a replaceable character


### PR DESCRIPTION
To maintain better readability, this PR reverses text direction on upside down.

Example text: `this is a reversed text`

Before: `ʇɥᴉs ᴉs ɐ ɹǝʌǝɹsǝp ʇǝxʇ`
After: `ʇxǝʇ pǝsɹǝʌǝɹ ɐ sᴉ sᴉɥʇ`